### PR TITLE
Add CI Workflow for Python Testing and Linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Pytesting & Pylinting
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  validation:
+    name: Pytesting & Pylinting
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.14'
+
+    - name: Install requirements
+      run: |
+        pip install -r requirements.txt
+
+    - name: Linting
+      run: pylint . --fail-under 8
+
+    - name: Testing
+      run: pytest .


### PR DESCRIPTION
This PR introduces a new GitHub Actions CI workflow to run Python tests and linting on pushes and pull requests to main.

Changes:

Adds a Pytesting & Pylinting workflow triggered on push and pull_request to main.
Configures a single validation job to set up Python, install dependencies, run pylint, and execute pytest.