### PR TITLE
Create Terraform Code For Historic Pipeline

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -278,3 +278,29 @@ resource "aws_lambda_function" "price_alerts" {
 resource "aws_ses_email_identity" "sender" {
   email = var.sender_email
 }
+
+resource "aws_ecr_repository" "historical_pipeline" {
+  name                 = "c21-commodities-historical-pipeline"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+}
+
+resource "aws_lambda_function" "historical_pipeline" {
+  function_name = "c21-commodities-historical-pipeline"
+  role          = aws_iam_role.lambda_role.arn
+  package_type  = "Image"
+  image_uri     = "${aws_ecr_repository.historical_pipeline.repository_url}:latest"
+  timeout       = 600
+  memory_size   = 1024
+
+  environment {
+    variables = {
+      DB_HOST     = aws_db_instance.postgres.address
+      DB_PORT     = "5432"
+      DB_NAME     = var.db_name
+      DB_USER     = var.db_username
+      DB_PASSWORD = var.db_password
+      API_KEY     = var.api_key
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces new infrastructure resources to support a historical data pipeline. The main changes are the addition of an Amazon ECR repository and a Lambda function configured to run as a container image for the historical pipeline.

**Infrastructure additions:**

* Added a new `aws_ecr_repository` resource named `historical_pipeline` to store container images for the historical pipeline.
* Added a new `aws_lambda_function` resource named `historical_pipeline` that runs from the ECR image, with increased timeout and memory, and environment variables for database and API access.