### PR TITLE
Fix Dashboard import syntax bug

### DIFF
--- a/dashboard/dashboard_items.py
+++ b/dashboard/dashboard_items.py
@@ -9,7 +9,7 @@ from psycopg2.extensions import connection
 
 from helper_functions import (clean_input,
                               authenticate_user_input,
-                              invoke_historical_lambda)
+                              invoke_historical_lambda,
                               find_new_commodity)
 
 from query_data import (get_market_data_by_ids,


### PR DESCRIPTION
This pull request makes a minor update to the `dashboard/dashboard_items.py` file by importing the `find_new_commodity` function from `helper_functions`. This change ensures that `find_new_commodity` is available for use in the dashboard item logic.

Closes #118 