### PR TITLE
Changed from pd.read_sql_query to using pyscopg2 cursor

### DIFF
--- a/dashboard/adv_analysis/adv_graph.py
+++ b/dashboard/adv_analysis/adv_graph.py
@@ -3,6 +3,7 @@
 import streamlit as st
 import pandas as pd
 from psycopg2 import connect
+from psycopg2.extras import RealDictCursor
 from os import environ as ENV
 from dotenv import load_dotenv
 import plotly.graph_objects as go
@@ -48,7 +49,10 @@ def fetch_data(commodity_id: int) -> pd.DataFrame:
         WHERE commodity_id = %s
     """
     with get_db_connection() as conn:
-        df = pd.read_sql_query(query, conn, params=(commodity_id,))
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(query, (commodity_id,))
+            results = cur.fetchall()
+    df = pd.DataFrame(results)
     return df
 
 


### PR DESCRIPTION
This pull request updates the way data is fetched from the database in `adv_graph.py` to use a dictionary-based cursor, which results in more robust and explicit handling of query results. The main changes are:

**Database query improvements:**

* Switched to using `RealDictCursor` from `psycopg2.extras` for database queries, enabling retrieval of results as dictionaries instead of default tuples.
* Modified the `fetch_data` function to use a manual cursor with `RealDictCursor` and `cur.fetchall()`, then convert the results to a DataFrame, instead of using `pd.read_sql_query`. This provides better control over the query execution and result formatting.